### PR TITLE
fix: prevent build-time API calls in v1-api-service

### DIFF
--- a/lib/services/v1-api-service.ts
+++ b/lib/services/v1-api-service.ts
@@ -3,9 +3,10 @@ import { Suggestion } from '@/types/revision';
 
 // Get base URL for client-side requests
 const getBaseUrl = () => {
-  // Server-side
+  // Server-side (build time or SSR)
   if (typeof window === 'undefined') {
-    return 'http://localhost:3000';
+    // During build, use environment variable or return empty to skip API calls
+    return process.env.NEXT_PUBLIC_APP_URL || '';
   }
   // Client-side
   return '';


### PR DESCRIPTION
Change getBaseUrl() to return empty string during build instead of localhost:3000. This prevents ECONNREFUSED errors during Vercel static generation.

- Use NEXT_PUBLIC_APP_URL env var if available during SSR
- Return empty string during build time to skip API calls
- Client-side calls continue to use relative URLs

Fixes the "connect ECONNREFUSED 127.0.0.1:3000" error during Vercel deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)