### PR TITLE
fix: allow disabling rate limit in production

### DIFF
--- a/lib/api/middleware/rate-limit.ts
+++ b/lib/api/middleware/rate-limit.ts
@@ -39,8 +39,8 @@ export function createRateLimiter(endpoint: string, config: RateLimitConfig = {}
   }
 
   return async function rateLimitMiddleware(request: NextRequest) {
-    // Skip rate limiting in development if DISABLE_RATE_LIMIT is set
-    if (process.env.NODE_ENV === 'development' && process.env.DISABLE_RATE_LIMIT === 'true') {
+    // Skip rate limiting if DISABLE_RATE_LIMIT is set (works in all environments)
+    if (process.env.DISABLE_RATE_LIMIT === 'true') {
       return null; // Continue to next middleware
     }
 


### PR DESCRIPTION
Change DISABLE_RATE_LIMIT check to work in all environments, not just development. This fixes the 429 Too Many Requests error during polling in production.

- Remove NODE_ENV === 'development' check
- Allow DISABLE_RATE_LIMIT to work in production
- Fixes polling timeout issue during Act 1 analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)