### PR TITLE
fix: add missing GET /api/v1/projects/[id] endpoint

### DIFF
--- a/app/api/v1/projects/[id]/route.ts
+++ b/app/api/v1/projects/[id]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withMiddleware } from '@/lib/api/middleware';
+import { createApiResponse } from '@/lib/api/response';
+import { handleApiError, NotFoundError } from '@/lib/api/errors';
+import { HTTP_STATUS } from '@/lib/config/constants';
+import { projectService } from '@/lib/db/services/project.service';
+
+interface RouteParams {
+  params: {
+    id: string;
+  };
+}
+
+// GET /api/v1/projects/[id] - Get project details
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  return withMiddleware(request, async () => {
+    try {
+      const { id } = params;
+
+      if (!id) {
+        throw new NotFoundError('Project ID is required');
+      }
+
+      // Fetch project
+      const project = await projectService.findById(id);
+
+      if (!project) {
+        throw new NotFoundError(`Project with ID ${id} not found`);
+      }
+
+      // Format response
+      return NextResponse.json(
+        createApiResponse({
+          id: project.id,
+          title: project.title,
+          description: project.description,
+          status: project.status,
+          workflowStatus: project.workflowStatus,
+          createdAt: project.createdAt.toISOString(),
+          updatedAt: project.updatedAt.toISOString()
+        }),
+        { status: HTTP_STATUS.OK }
+      );
+    } catch (error) {
+      return handleApiError(error);
+    }
+  });
+}


### PR DESCRIPTION
## Issue
Iteration page failed to load with 404 error when calling `v1ApiService.getProject()`:
- Error: "Failed to load project data: Error: <!DOCTYPE html>..."
- API endpoint `/api/v1/projects/[id]` was not implemented
- Only child routes existed ([id]/status, [id]/report, [id]/decisions)

## Root Cause
Missing API route handler for fetching individual project details. Frontend expects `GET /api/v1/projects/[id]` but it was never created.

## Changes Made
### New API Route (app/api/v1/projects/[id]/route.ts)
- Implements `GET /api/v1/projects/[id]` endpoint
- Fetches project details using `projectService.findById()`
- Returns formatted project data with workflow status
- Proper error handling with NotFoundError for missing projects
- Uses standard middleware and response formatting

### API Response Format
```json
{
  "success": true,
  "data": {
    "id": "project-id",
    "title": "Project Title",
    "description": "Description",
    "status": "ACTIVE",
    "workflowStatus": "ACT1_COMPLETE",
    "createdAt": "2025-10-09T...",
    "updatedAt": "2025-10-09T..."
  }
}
```

## Related Issue
This fixes the iteration page loading error reported in previous commit (59bfb03). The loading race condition fix revealed this missing API endpoint.

## Testing
- ✅ TypeScript type checking passed
- ✅ Production build successful
- ✅ New route appears in build output: `ƒ /api/v1/projects/[id]`

## Impact
- Iteration page can now load project data correctly
- No more 404 errors when navigating from Act 1 to Acts 2-5
- Complete V1 API coverage for project operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)